### PR TITLE
Added cvg_count and storage_set_id keys

### DIFF
--- a/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
+++ b/provisioning/miniprov/hare_mp/templates/hare.config.conf.tmpl.1-node
@@ -36,7 +36,9 @@
         }
       },
       "s3_instances": "TMPL_S3SERVER_INSTANCES_COUNT",
+      "storage_set_id": "TMPL_STORAGE_SET_ID",
       "storage": {
+      "cvg_count": "TMPL_CVG_COUNT",
         "cvg": [
           {
             "data_devices": [


### PR DESCRIPTION
Problem:

Miniprovisioner jenkins job failing for cvg_count & storage_set_id parameter, so adding cvg_count parameter in the template file.
http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Mini-Provisioning/job/CentOS-7.9.2009/job/Hare/5/console

Snippet of error :
```
23:29:18  fatal: [srvnode-1]: FAILED! => changed=true 
23:29:18    cmd: /opt/seagate/cortx/hare/bin/hare_setup config --config 'json:///opt/seagate/cortx/hare/conf/hare.config.conf.tmpl.1-node' --file '/var/lib/hare/cluster.yaml'
23:29:18    delta: '0:00:00.791333'
23:29:18    end: '2021-07-27 11:59:18.685174'
23:29:18    msg: non-zero return code
23:29:18    rc: 255
23:29:18    start: '2021-07-27 11:59:17.893841'
23:29:18    stderr: 2021-07-27 11:59:18,578 [ERROR] Error performing configuration (Required key 'server_node>8efd697708a8f7e428d3fd520c180795>storage>cvg_count' not found)
23:29:18    stderr_lines: <omitted>
23:29:18    stdout: ''
23:29:18    stdout_lines: <omitted>
```
```
11:32:44  fatal: [srvnode-1]: FAILED! => changed=true 
11:32:44    cmd: /opt/seagate/cortx/hare/bin/hare_setup config --config 'json:///opt/seagate/cortx/hare/conf/hare.config.conf.tmpl.1-node' --file '/var/lib/hare/cluster.yaml'
11:32:44    delta: '0:00:00.819430'
11:32:44    end: '2021-07-29 00:02:44.410383'
11:32:44    msg: non-zero return code
11:32:44    rc: 255
11:32:44    start: '2021-07-29 00:02:43.590953'
11:32:44    stderr: 2021-07-29 00:02:44,288 [ERROR] Error performing configuration (Required key 'server_node>8efd697708a8f7e428d3fd520c180795>storage_set_id' not found)
11:32:44    stderr_lines: <omitted>
11:32:44    stdout: ''
11:32:44    stdout_lines: <omitted>
```

Solution:
Added cvg_count and storage_set_id keys with TMPL values in the template file

Testing:
In later job this issue got resolved and hare_setup init worked well
http://eos-jenkins.colo.seagate.com/job/Cortx-PR-Build/job/Mini-Provisioning/job/CentOS-7.9.2009/job/Hare/20/console
Signed-off-by: Vaibhav Paratwar <vaibhav.paratwar@seagate.com>